### PR TITLE
ci: split release-please PRs per component

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-component-in-tag": true,
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## 概要
`release-please-config.json` の `separate-pull-requests` を `true` に変更し、コンポーネントごとに独立したリリース PR が開かれるようにします。

## 背景
モノリポでは各コンポーネントを独自のスケジュールでリリースしたいケースが多く、集約型 PR (`separate-pull-requests: false`) だと全コンポーネントを同時にしかリリースできず柔軟性に欠けます。コンポーネントごとに独立した PR にすることで、

- 各コンポーネントを別々のタイミングでリリース可能
- マージ時に該当コンポーネントのタグ (例: `unary-v1.0.0`) のみが切られ、Docker image ビルド等の下流フローと自然に連携できる

## 影響
- 本 PR がマージされると、release-please は現在の集約型 PR #56 を自動でクローズし、代わりにコンポーネント単位の PR を新規作成します (今回のリリース対象は 9 コンポーネント)。

## テスト計画
- [ ] 本 PR をマージする。
- [ ] 集約 PR #56 が自動クローズされることを確認する。
- [ ] コンポーネント数分のリリース PR が新規作成されることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)