### PR TITLE
ci: drop branch name from release-please PR titles

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "go",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## 概要
release-please が生成するリリース PR のタイトルから `(master)` を取り除きます。

## 変更内容
`release-please-config.json` に以下を追加:

\`\`\`json
"pull-request-title-pattern": "chore: release\${component} \${version}"
\`\`\`

## Before / After

| | タイトル |
|---|---|
| Before (デフォルト) | `chore(master): release client-side-lb 1.0.0` |
| After | `chore: release client-side-lb 1.0.0` |

`(master)` はターゲットブランチ名で、`master` 単一ブランチからしかリリースしない構成では意味のある情報ではないため省略します。

## 影響
本 PR をマージ後、release-please は既存のリリース PR を **新タイトルで再生成** します (古い PR は自動でクローズされ、同等内容の PR が新タイトルで作り直される)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)