### PR TITLE
ci: use component name as scope in release PR titles

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
   "release-type": "go",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore: release${component} ${version}",
+  "component-no-space": true,
+  "pull-request-title-pattern": "chore(${component}): release ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## 概要
PR #68 で導入した `pull-request-title-pattern` を、コンポーネント名を Conventional Commits の scope 位置に置く形に変更します。あわせて `component-no-space: true` を有効化します。

## 変更内容
```diff
- "pull-request-title-pattern": "chore: release${component} ${version}",
+ "component-no-space": true,
+ "pull-request-title-pattern": "chore(${component}): release ${version}",
```

## Before / After

| | タイトル |
|---|---|
| 現在 (PR #68 マージ後) | `chore: release client-side-lb 1.0.0` |
| 本 PR マージ後 | `chore(client-side-lb): release 1.0.0` |

## 背景
release-please は `${component}` を **先頭に半角スペース付き** で展開するデフォルト挙動になっています ([pull-request-title.ts](https://github.com/googleapis/release-please/blob/main/src/util/pull-request-title.ts))。これは「単一パッケージ時に余計な空白を生まないようにする」ためのセパレータ埋め込みですが、`${component}` を scope 位置 (`chore(${component}):`) に置くと `chore( client-side-lb):` のように崩れます。

`component-no-space: true` を有効化することで `${component}` がコンポーネント名そのものに展開され、Conventional Commits スタイル (`chore(scope): subject`) に沿った PR タイトルになります。モノリポでコンポーネントを scope として使う方が PR 一覧の視認性が高く、commitlint の通常の Conventional Commits 検査もそのまま通る形になります。

## 影響
本 PR をマージ後、release-please は既存の `chore: release ...` 形式のリリース PR を新タイトル (`chore(component): release ...`) で再生成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)