### PR TITLE
ci: serialize release-please workflow runs to avoid race conditions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要
`release-please.yml` に `concurrency` 設定を追加し、release-please workflow が同時並走しないようにします。

## 背景
複数のリリース PR を短時間に連続マージしたところ、master のスキャン中に他の workflow がまだ走っている状態で次の workflow が起動し、stale な manifest を元に判断した結果、**既にリリース済みのコンポーネント (enum-compatibility / metadata) に対して 1.0.0 の重複リリース PR (#80 / #81) が生成される race condition** が発生しました。

タイムライン上、PR #75 / #77 / #72 が 20 秒以内にマージされており、各 workflow run (~1 分) が並走していたことがログから確認できています。

## 変更内容
\`\`\`yaml
concurrency:
  group: release-please-\${{ github.ref }}
  cancel-in-progress: false
\`\`\`

- `group` を ref 単位 (= master 単位) で固定し、同時実行を 1 つに制限
- `cancel-in-progress: false` で、走行中の workflow は完了まで動かす

## キュー上書き問題への補足
GitHub Actions の concurrency は「running 1 + pending 1」のスロット制で、3 つ目以降の workflow は pending を上書きする仕様 ([community discussion #41518](https://github.com/orgs/community/discussions/41518))。ただし release-please-action は実行のたびに master の現在状態をフルスキャンするベキ等な設計のため、上書きで失われた中間 run の仕事は最後の run が拾う形で吸収されます。今回の race condition (running 並走) は本変更で解消、pending 上書き問題は実害なしと判断します。

## テスト計画
- [ ] 本 PR をマージする。
- [ ] 今後リリース PR を 2 件以上同時マージしても重複 PR が出ないことを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)