### PR TITLE
ci: use slash separator for component tags (Go module convention)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
   "include-component-in-tag": true,
+  "tag-separator": "/",
   "separate-pull-requests": true,
   "component-no-space": true,
   "pull-request-title-pattern": "chore(${component}): release ${version}",


### PR DESCRIPTION
## 概要
release-please の `tag-separator` を `/` に変更し、コンポーネントタグを `<component>/v<version>` 形式 (例: `unary/v1.0.0`) に揃えます。

## 背景
`release-type: go` でも release-please のデフォルトタグ区切り文字は `-` なので、現状は `unary-v1.0.0` 形式のタグが切られています。

しかし Go の module system では、サブディレクトリに go.mod を持つモジュールを `go get` で取得する際、タグが **`<subpath>/v<version>`** 形式である必要があります:

```bash
# このコマンドが解決するために必要なタグは "unary/v1.0.0"
go get github.com/jun06t/grpc-sample/unary@v1.0.0
```

そのため `unary-v1.0.0` ではユーザーが go get で取得できません。googleapis/google-cloud-go など主要な Go monorepo もすべて `pubsub/v2.6.0` のような `/` 区切り形式を採用しています。

## 変更内容
```diff
+ "tag-separator": "/",
```

## 影響
- **次回以降のリリース**: タグが `<component>/v<version>` 形式で切られる
- **既存タグ** (`bazel-v1.0.0` など 8 件): 自動マイグレーションは行われない。go get 経由で取得可能にしたい場合は別途手動でリタグが必要

## 既存タグのリタグ (任意)
必要なら以下のような手順で同じコミットに新形式のタグを追加できます:

```bash
for old in bazel-v1.0.0 client-side-lb-v1.0.0 enum-compatibility-v1.0.0 fieldmask-v1.0.0 metadata-v1.0.0 openapi-v1.0.0 server-reflection-v1.0.0 wait-for-ready-v1.0.0; do
  new="${old/-v/\/v}"
  git tag "$new" "$old"
  git push origin "$new"
done
```

旧タグ (`-v` 形式) は残しておいても害はないですが、混乱を避けたければ削除可能です。

## テスト計画
- [ ] 本 PR をマージする。
- [ ] 次回リリース PR (例: unary 1.0.1) をマージし、タグが `unary/v1.0.1` 形式で切られることを確認する。
- [ ] (任意) 既存タグをリタグして go get で取得できることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)