### PR TITLE
ci: use GitHub App token for release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,12 +17,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json


### PR DESCRIPTION
## 概要
release-please workflow が使うトークンを GITHUB_TOKEN から GitHub App 発行のインストールトークンへ切り替えます。

## 背景
GITHUB_TOKEN で作られたタグや push は **他の workflow を起動しない** 仕様です ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow))。release-please が自動で切るタグを起点に Docker build / デプロイ等の下流 workflow を発火させる典型パターンが、デフォルトのままでは成立しません。

GitHub App から発行したインストールトークンを使うとこの制約を回避でき、release-please が打ったタグから後続 workflow を連鎖起動できます。あわせて、リリース PR / タグ / GitHub Release の作成者が `github-actions[bot]` ではなく App 名 (例: `release-please-bot[bot]`) で表示されるようになり、ノイズ除外の指定 (CODEOWNERS / Greptile 等) もより明確になります。

## 変更内容
```yaml
steps:
  - uses: actions/create-github-app-token@v1
    id: app-token
    with:
      app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
      private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
  - uses: googleapis/release-please-action@v4
    with:
      token: ${{ steps.app-token.outputs.token }}
      ...
```

## 前提
リポジトリに以下の Secrets が設定済みであること (登録済み):
- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_PRIVATE_KEY`

GitHub App は本リポジトリにインストールされ、最低限以下の権限を持つこと:
- Repository permissions: **Contents: Read & write**
- Repository permissions: **Pull requests: Read & write**

## テスト計画
- [ ] 本 PR をマージする
- [ ] release-please workflow が正常に成功する
- [ ] (任意) 次のリリース PR の Author が App ([bot]) になっていることを確認する
- [ ] (任意) リリース PR をマージし、タグの push をトリガーに別 workflow が起動できることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)