### PR TITLE
feat: scaffold BuildVersion constant for release-please marker test

### DIFF
--- a/keepalive/client/version.go
+++ b/keepalive/client/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.0"
+// x-release-please-end

--- a/keepalive/server/version.go
+++ b/keepalive/server/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.0"
+// x-release-please-end

--- a/metadata/client/version.go
+++ b/metadata/client/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.1"
+// x-release-please-end

--- a/metadata/server/version.go
+++ b/metadata/server/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.1"
+// x-release-please-end

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,8 +36,14 @@
     "graceful": { "component": "graceful" },
     "grpc-gateway": { "component": "grpc-gateway" },
     "image-proxy": { "component": "image-proxy" },
-    "keepalive": { "component": "keepalive" },
-    "metadata": { "component": "metadata" },
+    "keepalive": {
+      "component": "keepalive",
+      "extra-files": ["server/version.go", "client/version.go"]
+    },
+    "metadata": {
+      "component": "metadata",
+      "extra-files": ["server/version.go", "client/version.go"]
+    },
     "multiple-interceptors": { "component": "multiple-interceptors" },
     "openapi": { "component": "openapi" },
     "protoc": { "component": "protoc" },
@@ -45,7 +51,10 @@
     "same-package": { "component": "same-package" },
     "server-reflection": { "component": "server-reflection" },
     "server-streaming": { "component": "server-streaming" },
-    "unary": { "component": "unary" },
+    "unary": {
+      "component": "unary",
+      "extra-files": ["server/version.go", "client/version.go"]
+    },
     "wait-for-ready": { "component": "wait-for-ready" }
   }
 }

--- a/unary/client/version.go
+++ b/unary/client/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.1"
+// x-release-please-end

--- a/unary/server/version.go
+++ b/unary/server/version.go
@@ -1,0 +1,5 @@
+package main
+
+// x-release-please-start-version
+const BuildVersion = "1.0.1"
+// x-release-please-end


### PR DESCRIPTION
## Summary

各 component (unary / metadata / keepalive) の server / client バイナリに `BuildVersion` 定数を追加し、release-please のバージョンマーカーで囲む。`release-please-config.json` の各 package に `extra-files` を登録し、Release PR 作成時に release-please が自動で `BuildVersion` を次バージョンに書き換える形にする。

将来的に Cloud Profiler / OpenTelemetry の `service.version` として参照する想定。

## Phase 1 検証ゴール

このマージ後に Release Please workflow が走り、以下が観測できることを確認したい:

- `unary`, `metadata`, `keepalive` それぞれに Release PR が立つ（path filter で発火）
- 各 Release PR の差分に `server/version.go` と `client/version.go` の `BuildVersion` 行が新バージョンへ書き換わっている

## Notes

各 component の version.go を実際に touch しているので path filter だけで全 component が発火する。各 CHANGELOG には PR タイトルがそのまま入る想定。