### PR TITLE
chore: switch version.go to inline release-please marker

### DIFF
--- a/keepalive/client/version.go
+++ b/keepalive/client/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version

--- a/keepalive/server/version.go
+++ b/keepalive/server/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version

--- a/metadata/client/version.go
+++ b/metadata/client/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version

--- a/metadata/server/version.go
+++ b/metadata/server/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version

--- a/unary/client/version.go
+++ b/unary/client/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version

--- a/unary/server/version.go
+++ b/unary/server/version.go
@@ -1,5 +1,3 @@
 package main
 
-// x-release-please-start-version
-const BuildVersion = "1.1.1"
-// x-release-please-end
+const BuildVersion = "1.1.1" // x-release-please-version


### PR DESCRIPTION
## Summary

block marker (`x-release-please-start-version` / `x-release-please-end`) ではなく、行末注釈 `// x-release-please-version` 1 行に切り替える。

block marker は const と end-marker コメントの間に gofmt が空行を要求するため、運用上のノイズになる。行末注釈の単一行マーカーなら自然な Go コードのまま release-please の自動 bump も動く。

## 検証ゴール

マージ後、release-please workflow が走り:
- 3 component (unary / metadata / keepalive) の Release PR が立つ（path filter は前回と同じ仕組み）
- 各 Release PR で version.go の `BuildVersion` が次バージョンに自動書き換わる（行末注釈でも置換が機能することの確認）